### PR TITLE
Add link to Rafe's talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Error Handling Workshop
+Inspired by @rjmk and his [error handling talk](https://github.com/rjmk/fac-error-talk)
 
 ![Undefined Error Pic](./docs/node-error.png)
 
@@ -185,11 +186,12 @@ Your router should call a handler which utilises the *validateName*, *validateAg
 
 ### Resources
 - [ES6 Features- Destructuring](http://es6-features.org/#ParameterContextMatching)
-- [Proper Error Handling in JavaScript](https://www.sitepoint.com/proper-error-handling-javascript/)
 - [The Beginner's Guide to Type Coercion: A Practical Example](https://code.tutsplus.com/articles/the-beginners-guide-to-type-coercion-a-practical-example--cms-21998)
 - [404 Error Pages](https://www.smashingmagazine.com/2009/01/404-error-pages-one-more-time/)
 - [MDN- Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
 - [MDN- instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof)
 - [Post Requests in Node](http://stackoverflow.com/questions/4295782/how-do-you-extract-post-data-in-node-js)
 - [Shot Documentation](https://github.com/hapijs/shot)
-- [Joyent- Error Handling](https://www.joyent.com/node-js/production/design/errors)
+- [Joyent- Error Handling in Node.js](https://www.joyent.com/node-js/production/design/errors)
+- [Rafe's (@rjmk) Error Handling Talk](https://github.com/rjmk/fac-error-talk)
+- [Proper Error Handling in JavaScript](https://www.sitepoint.com/proper-error-handling-javascript/)


### PR DESCRIPTION
* Add link to Rafe's talk to top of page and list of resources
* Move "Proper Error Handling" link down to the bottom; the Joyent link is _MUCH_ better and clearer